### PR TITLE
Fix #99: InterpretationWindow() not callable

### DIFF
--- a/pymol_plugin_dynamics.py
+++ b/pymol_plugin_dynamics.py
@@ -1814,10 +1814,6 @@ class InterpretationWindow:
 ## Show interpretation window...
 def showInterpretationWindow():
 	interpretation = InterpretationWindow()
-	try:
-		interpretation()
-	except AttributeError:
-		pass
 
 ##Gather all water options windows in one class
 class WaterWindows:


### PR DESCRIPTION
This code was never functional, and raises `TypeError` in Python 3.